### PR TITLE
Add a script to build the server dll

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build server code
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Configure msvc
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+      - run: msbuild ep6/server/sdev/sdev.vcxproj /p:configuration=debug /p:platform=win32
+      - uses: actions/upload-artifact@v1
+        with:
+          name: sdev.dll
+          path: ep6/server/sdev/debug/sdev.dll
+


### PR DESCRIPTION
This adds a simple Github action that builds the server library, and uploads the compiled artifact when it's finished. This is helpful for knowing when the code does or doesn't actually compile.