### PR TITLE
Fix: Correct market search index capping

### DIFF
--- a/sdev/src/packet_market.cpp
+++ b/sdev/src/packet_market.cpp
@@ -12,15 +12,15 @@ void __declspec(naked) naked_0x486319()
         // search index
         movzx eax,byte ptr[ebp+0x5]
         cmp eax,0x13
-        jge decrement
+        jge fix_index             // If index is >= 0x13 (19), jump to fix_index
 
-        original:
+        original_path:            // Label for the original execution path
         lea ecx,[ebp+0x7]
         jmp u0x486320
 
-        decrement:
-        dec eax
-        jmp original
+        fix_index:
+        mov eax,0x12              // Set index to 0x12 (18)
+        jmp original_path         // Jump to the original execution path
     }
 }
 


### PR DESCRIPTION
The previous assembly code in `naked_0x486319` for handling the market search index had a flaw. If an input index was `0x14` (20) or higher, it would be decremented to `0x13` (19). If your valid 0-based index range for the search is `0-18`, this would still result in an out-of-bounds access when the original function `u0x486320` was called with index 19.

This change modifies the assembly logic to ensure that any index `0x13` (19) or greater is correctly capped to `0x12` (18) before calling the original function. This should prevent out-of-bounds access and resolve related "seaRCH ERRORS".